### PR TITLE
#2: Handle buffer size and other errors properly

### DIFF
--- a/iconvcodec.py
+++ b/iconvcodec.py
@@ -4,17 +4,19 @@ def codec_factory(encoding):
     encoder = iconv.open(encoding, "utf-8")
     decoder = iconv.open("utf-8", encoding)
 
-    def encode(input, errors="strict"):
+    def encode(input, errors="strict", bufsize=None):
         msg = input.encode()
+
+        if bufsize is None:
+            bufsize = len(msg)
+
         try:
-            return encoder.iconv(msg), len(msg)
+            return encoder.iconv(msg, bufsize), len(msg)
         except iconv.error as e:
             errstring, code, inlen, outres = e.args
-            assert inlen % 2 == 0
-            inlen /= 2
             if code == errno.E2BIG:
-                # outbuffer was too small, try to encode rest
-                out1, len1 = encode(msg[inlen:], errors)
+                # outbuffer was too small, increase size a bit and try to encode rest
+                out1, len1 = encode(msg[inlen :].decode(), errors, bufsize - inlen + max(bufsize // 10, 3))
                 return outres + out1, inlen + len1
             if code == errno.EINVAL:
                 # An incomplete multibyte sequence has been
@@ -27,22 +29,25 @@ def codec_factory(encoding):
                 if errors == "strict":
                     raise UnicodeError(*e.args)
                 if errors == "replace":
-                    out1, len1 = encode(u"?" + msg[inlen + 1 :], errors)
+                    out1, len1 = encode((u"?" + msg[inlen :].decode()[1:]), errors)
                 elif errors == "ignore":
-                    out1, len1 = encode(msg[inlen + 1 :], errors)
+                    out1, len1 = encode(msg[inlen :].decode()[1:], errors)
                 else:
                     raise ValueError("unsupported error handling")
-                return outres + out1, inlen + 1 + len1
+                return outres + out1, inlen + len1 + 1
             raise
 
-    def decode(msg, errors="strict"):
+    def decode(msg, errors="strict", bufsize=None):
+        if bufsize is None:
+            bufsize = len(msg)
+
         try:
-            return decoder.iconv(msg).decode(), len(msg)
+            return decoder.iconv(msg, bufsize).decode(), len(msg)
         except iconv.error as e:
             errstring, code, inlen, outres = e.args
             if code == errno.E2BIG:
                 # buffer too small
-                out1, len1 = decode(msg[inlen:], errors)
+                out1, len1 = decode(msg[inlen:], errors, bufsize - inlen + max(bufsize // 10, 3))
                 return outres.decode() + out1, inlen + len1
             if code == errno.EINVAL:
                 # An incomplete multibyte sequence has been
@@ -55,13 +60,13 @@ def codec_factory(encoding):
                 if errors == "strict":
                     raise UnicodeError(*e.args)
                 if errors == "replace":
-                    outres += u"\uFFFD"
-                    out1, len1 = decode(msg[inlen:], errors)
+                    outres += u"\uFFFD".encode()
+                    out1, len1 = decode(msg[inlen + 1:], errors)
                 elif errors == "ignore":
-                    out1, len1 = decode(msg[inlen:], errors)
+                    out1, len1 = decode(msg[inlen + 1:], errors)
                 else:
                     raise ValueError("unsupported error handling")
-                return outres.decode() + out1, inlen + len1
+                return outres.decode() + out1, inlen + len1 + 1
 
     return encode, decode
 

--- a/iconvcodec.py
+++ b/iconvcodec.py
@@ -1,72 +1,82 @@
 import sys, iconv, codecs, errno
 
+
+_ENCODE_REPLACECHAR = '?'.encode()
+_DECODE_REPLACECHAR = u'\uFFFD'.encode()
+
+def _iconv_encode_impl(encoder, msg, errors, bufsize=None):
+    if bufsize is None:
+        bufsize = len(msg)
+
+    try:
+        return encoder.iconv(msg, bufsize), len(msg)
+    except iconv.error as e:
+        errstring, code, inlen, outres = e.args
+        if code == errno.E2BIG:
+            # outbuffer was too small, increase size a bit and try to encode rest
+            out1, len1 = _iconv_encode_impl(encoder, msg[inlen :], errors, bufsize - inlen + max(bufsize // 10, 3))
+            return outres + out1, inlen + len1
+        if code == errno.EINVAL:
+            # An incomplete multibyte sequence has been
+            # encountered in the input. Should not happen in Unicode
+            raise AssertionError("EINVAL in encode")
+        if code == errno.EILSEQ:
+            # An invalid multibyte sequence has been encountered
+            # in the input. Used to indicate that the character is
+            # not supported in the target code
+            if errors == "strict":
+                raise UnicodeError(*e.args)
+            if errors == "replace":
+                out1, len1 = _iconv_encode_impl(encoder, (_ENCODE_REPLACECHAR + msg[inlen :].decode()[1:].encode()), errors)
+            elif errors == "ignore":
+                out1, len1 = _iconv_encode_impl(encoder, msg[inlen :].decode()[1:].encode(), errors)
+            else:
+                raise ValueError("unsupported error handling")
+            return outres + out1, inlen + len1 + 1
+        raise
+
+def _iconv_decode_impl(decoder, msg, errors, bufsize=None):
+    if bufsize is None:
+        bufsize = len(msg)
+
+    try:
+        return decoder.iconv(msg, bufsize).decode(), len(msg)
+    except iconv.error as e:
+        errstring, code, inlen, outres = e.args
+        if code == errno.E2BIG:
+            # buffer too small
+            out1, len1 = _iconv_decode_impl(decoder, msg[inlen:], errors, bufsize - inlen + max(bufsize // 10, 3))
+            return outres.decode() + out1, inlen + len1
+        if code == errno.EINVAL:
+            # An incomplete multibyte sequence has been
+            # encountered in the input.
+            return outres.decode(), inlen
+        if code == errno.EILSEQ:
+            # An invalid multibyte sequence has been encountered
+            # in the input. Ignoring or replacing it is hard to
+            # achieve, just try one character at a time
+            if errors == "strict":
+                raise UnicodeError(*e.args)
+            if errors == "replace":
+                outres += _DECODE_REPLACECHAR
+                out1, len1 = _iconv_decode_impl(decoder, msg[inlen + 1:], errors)
+            elif errors == "ignore":
+                out1, len1 = _iconv_decode_impl(decoder, msg[inlen + 1:], errors)
+            else:
+                raise ValueError("unsupported error handling")
+            return outres.decode() + out1, inlen + len1 + 1
+
 def codec_factory(encoding):
     encoder = iconv.open(encoding, "utf-8")
     decoder = iconv.open("utf-8", encoding)
 
-    def encode(input, errors="strict", bufsize=None):
-        msg = input.encode()
+    def encode(inp, errors="strict"):
+        msg = inp.encode()
 
-        if bufsize is None:
-            bufsize = len(msg)
+        return _iconv_encode_impl(encoder, msg, errors)
 
-        try:
-            return encoder.iconv(msg, bufsize), len(msg)
-        except iconv.error as e:
-            errstring, code, inlen, outres = e.args
-            if code == errno.E2BIG:
-                # outbuffer was too small, increase size a bit and try to encode rest
-                out1, len1 = encode(msg[inlen :].decode(), errors, bufsize - inlen + max(bufsize // 10, 3))
-                return outres + out1, inlen + len1
-            if code == errno.EINVAL:
-                # An incomplete multibyte sequence has been
-                # encountered in the input. Should not happen in Unicode
-                raise AssertionError("EINVAL in encode")
-            if code == errno.EILSEQ:
-                # An invalid multibyte sequence has been encountered
-                # in the input. Used to indicate that the character is
-                # not supported in the target code
-                if errors == "strict":
-                    raise UnicodeError(*e.args)
-                if errors == "replace":
-                    out1, len1 = encode((u"?" + msg[inlen :].decode()[1:]), errors)
-                elif errors == "ignore":
-                    out1, len1 = encode(msg[inlen :].decode()[1:], errors)
-                else:
-                    raise ValueError("unsupported error handling")
-                return outres + out1, inlen + len1 + 1
-            raise
-
-    def decode(msg, errors="strict", bufsize=None):
-        if bufsize is None:
-            bufsize = len(msg)
-
-        try:
-            return decoder.iconv(msg, bufsize).decode(), len(msg)
-        except iconv.error as e:
-            errstring, code, inlen, outres = e.args
-            if code == errno.E2BIG:
-                # buffer too small
-                out1, len1 = decode(msg[inlen:], errors, bufsize - inlen + max(bufsize // 10, 3))
-                return outres.decode() + out1, inlen + len1
-            if code == errno.EINVAL:
-                # An incomplete multibyte sequence has been
-                # encountered in the input.
-                return outres.decode(), inlen
-            if code == errno.EILSEQ:
-                # An invalid multibyte sequence has been encountered
-                # in the input. Ignoring or replacing it is hard to
-                # achieve, just try one character at a time
-                if errors == "strict":
-                    raise UnicodeError(*e.args)
-                if errors == "replace":
-                    outres += u"\uFFFD".encode()
-                    out1, len1 = decode(msg[inlen + 1:], errors)
-                elif errors == "ignore":
-                    out1, len1 = decode(msg[inlen + 1:], errors)
-                else:
-                    raise ValueError("unsupported error handling")
-                return outres.decode() + out1, inlen + len1 + 1
+    def decode(msg, errors="strict"):
+        return _iconv_decode_impl(decoder, msg, errors)
 
     return encode, decode
 


### PR DESCRIPTION
This is my first time working on an implementation of the codec API so please be patient if I did anything stupid.

Changes:
* If output buffer is too small, make it bigger when trying again
* Fix indexing confusion (`msg` is bytes, index returned by error can be used unmodified).
* Pass input to encode retries in correct format (and fix a few other typing issues).
* If decode fails due to an invalid sequence with `errors='ignore'` or `errors='replace'`, remove the offending byte before retrying.

When the buffer is too small, I increase it by 10% (min 3 bytes). I chose those numbers based on nothing whatsoever, and I'm open to other suggestions.

The unit tests succeed, and this works for my use cases plus some others I fiddled around with, but I wouldn't say it has been tested extensively.