### PR TITLE
Fix to build on windows

### DIFF
--- a/iconvcodec.py
+++ b/iconvcodec.py
@@ -2,7 +2,7 @@ import sys, iconv, codecs, errno
 
 
 _ENCODE_REPLACECHAR = "?".encode()
-_DECODE_REPLACECHAR = u"\uFFFD".encode()
+_DECODE_REPLACECHAR = "\ufffd".encode()
 
 
 def _iconv_encode_impl(encoder, msg, errors, bufsize=None):

--- a/iconvmodule.c
+++ b/iconvmodule.c
@@ -56,7 +56,7 @@ Iconv_iconv(IconvObject *self, PyObject *args, PyObject* kwargs)
 {
     PyObject *inbuf_obj;
     Py_buffer inbuf_view;
-    const char *inbuf;
+    char *inbuf;
     char *outbuf;
     size_t inbuf_size, outbuf_size, iresult;
     long int inbuf_size_int, outbuf_size_int = -1;

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ as well as a Python codec to convert between Unicode objects and
 all iconv-provided encodings.
 """,
     py_modules=["iconvcodec"],
-    ext_modules=[Extension("iconv", sources=["iconvmodule.c"])],
+    ext_modules=[Extension("iconv", sources=["iconvmodule.c"], libraries=['iconv'])],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, Extension
 
 setup(
     name="python-iconv",
-    version="1.1.2",
+    version="1.1.3",
     description="iconv-based Unicode converter",
     author="Bodo Graumann",
     author_email="mail@bodograumann.de",

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ as well as a Python codec to convert between Unicode objects and
 all iconv-provided encodings.
 """,
     py_modules=["iconvcodec"],
-    ext_modules=[Extension("iconv", sources=["iconvmodule.c"], libraries=['iconv'])],
+    ext_modules=[Extension("iconv", sources=["iconvmodule.c"], libraries=["iconv"])],
 )


### PR DESCRIPTION
On Windows, `pip install python-iconv` fail because linker cannot resolve symbol `libiconv_close()`  etc.
This is because library to link is not specified in `setup.py`.
And  also type error on calling `iconv()`. We should use `char *inbuf` intead of `const char *` to call.