### PR TITLE
`PyErr_NewException` can return `NULL`

### DIFF
--- a/iconvmodule.c
+++ b/iconvmodule.c
@@ -189,6 +189,9 @@ PyInit_iconv(void)
     /* Add some symbolic constants to the module */
     d = PyModule_GetDict(m);
     error = PyErr_NewException("iconv.error", PyExc_ValueError, NULL);
+    if (error == NULL) {
+        return NULL;
+    }
     PyDict_SetItemString(d, "error", error);
 
     return m;


### PR DESCRIPTION
E.g.:

https://github.com/python/cpython/blob/d12cbf2865d2845d238f697ddace83face814972/Modules/_interpchannelsmodule.c#L188-L191